### PR TITLE
REF: Move input specifications to separate classes

### DIFF
--- a/pydra/tasks/freesurfer/mri_convert.py
+++ b/pydra/tasks/freesurfer/mri_convert.py
@@ -1,6 +1,36 @@
+import attrs
+
 import pydra
 
 __all__ = ["MRIConvert"]
+
+
+@attrs.define(slots=False, kw_only=True)
+class MRIConvertSpec(pydra.specs.ShellSpec):
+    input_volume: str = attrs.field(
+        metadata={
+            "help_string": "input volume",
+            "mandatory": True,
+            "argstr": "",
+            "position": 1,
+        }
+    )
+
+    output_volume: str = attrs.field(
+        metadata={
+            "help_string": "output volume",
+            "argstr": "",
+            "position": 2,
+            "output_file_template": "{input_volume}_converted.nii.gz",
+        }
+    )
+
+    output_data_type: str = attrs.field(
+        metadata={
+            "help_string": "output data type",
+            "argstr": "-odt",
+        }
+    )
 
 
 class MRIConvert(pydra.ShellCommandTask):
@@ -24,37 +54,7 @@ class MRIConvert(pydra.ShellCommandTask):
 
     input_spec = pydra.specs.SpecInfo(
         name="MRIConvertInput",
-        fields=[
-            (
-                "input_volume",
-                str,
-                {
-                    "help_string": "input volume",
-                    "mandatory": True,
-                    "argstr": "{input_volume}",
-                    "position": 1,
-                },
-            ),
-            (
-                "output_volume",
-                str,
-                {
-                    "help_string": "output volume",
-                    "argstr": "{output_volume}",
-                    "position": 2,
-                    "output_file_template": "{input_volume}_converted.nii.gz",
-                },
-            ),
-            (
-                "output_data_type",
-                str,
-                {
-                    "help_string": "output data type",
-                    "argstr": "-odt {output_data_type}",
-                },
-            ),
-        ],
-        bases=(pydra.specs.ShellSpec,),
+        bases=(MRIConvertSpec, pydra.specs.ShellSpec),
     )
 
     executable = "mri_convert"

--- a/pydra/tasks/freesurfer/specs.py
+++ b/pydra/tasks/freesurfer/specs.py
@@ -38,7 +38,7 @@ class HemisphereSpec(pydra.specs.ShellSpec):
 
     hemisphere: str = attrs.field(
         metadata={
-            "help_string": "restrict processing to hemisphere",
+            "help_string": "restrict processing to left or right hemisphere",
             "argstr": "--hemi {hemisphere}",
             "allowed_values": ["lh", "rh"],
         }

--- a/pydra/tasks/freesurfer/tkregister2.py
+++ b/pydra/tasks/freesurfer/tkregister2.py
@@ -1,8 +1,42 @@
+import attrs
+
 import pydra
 
-from . import specs
-
 __all__ = ["TkRegister2"]
+
+
+@attrs.define(slots=False, kw_only=True)
+class TkRegister2Spec(pydra.specs.ShellSpec):
+    moving_volume: str = attrs.field(
+        metadata={
+            "help_string": "moving volume",
+            "mandatory": True,
+            "argstr": "--mov",
+        }
+    )
+
+    target_volume: str = attrs.field(
+        metadata={
+            "help_string": "target volume",
+            "mandatory": True,
+            "argstr": "--targ",
+        }
+    )
+
+    registration_file: str = attrs.field(
+        metadata={
+            "help_string": "registration file in FreeSurfer's format",
+            "argstr": "--reg",
+            "output_file_template": "{registration_file}",
+        }
+    )
+
+    compute_registration_from_headers: bool = attrs.field(
+        metadata={
+            "help_string": "compute registration from the headers of the input volumes",
+            "argstr": "--regheader",
+        }
+    )
 
 
 class TkRegister2(pydra.ShellCommandTask):
@@ -20,82 +54,15 @@ class TkRegister2(pydra.ShellCommandTask):
     ...     moving_volume="rawavg.mgz",
     ...     target_volume="orig.mgz",
     ...     registration_file="register.native.dat",
-    ...     init_registration_from_headers=True,
+    ...     compute_registration_from_headers=True,
     ... )
     >>> task.cmdline
     'tkregister2 --noedit --mov rawavg.mgz --targ orig.mgz --reg register.native.dat --regheader'
-
-    2. Create a registration matrix for a smaller field-of-view of the talairach atlas:
-
-    >>> task = TkRegister2(
-    ...     target_volume="mni305.cor.mgz",
-    ...     moving_volume="mni305.cor.subfov1.mgz",
-    ...     init_registration_from_headers=True,
-    ...     registration_file="mni305.cor.subfov1.reg",
-    ...     subject_id="fsaverage",
-    ... )
-    >>> task.cmdline
-    'tkregister2 --noedit --mov mni305.cor.subfov1.mgz --targ mni305.cor.mgz --reg mni305.cor.subfov1.reg --regheader \
---s fsaverage'
     """
 
     input_spec = pydra.specs.SpecInfo(
         name="TkRegister2Input",
-        fields=[
-            (
-                "moving_volume",
-                str,
-                {
-                    "help_string": "moving volume",
-                    "mandatory": True,
-                    "argstr": "--mov {moving_volume}",
-                },
-            ),
-            (
-                "target_volume",
-                str,
-                {
-                    "help_string": "target volume",
-                    "argstr": "--targ {target_volume}",
-                    "xor": {"fs_target_volume"},
-                },
-            ),
-            (
-                "fs_target_volume",
-                bool,
-                {
-                    "help_string": "use T1 volume from subject found in the input registration matrix",
-                    "argstr": "--fstarg",
-                    "xor": {"target_volume"},
-                },
-            ),
-            (
-                "registration_file",
-                str,
-                {
-                    "help_string": "input or output registration file",
-                    "argstr": "--reg {registration_file}",
-                    "output_file_template": "{registration_file}",
-                },
-            ),
-            (
-                "init_registration_from_headers",
-                bool,
-                {
-                    "help_string": "compute the initial registration from the input volumes headers",
-                    "argstr": "--regheader",
-                },
-            ),
-            (
-                "subject_id",
-                str,
-                {
-                    "help_string": "user defined subject identifier",
-                    "argstr": "--s {subject_id}",
-                },
-            ),
-        ],
-        bases=(specs.SubjectsDirSpec,),
+        bases=(TkRegister2Spec, pydra.specs.ShellSpec),
     )
 
     executable = "tkregister2 --noedit"


### PR DESCRIPTION
Refactor input spec definitions to their own class, which should facilitate generation of the corresponding documentation by Sphinx later on.