### PR TITLE
FIX: Use consistent naming for file parameters

### DIFF
--- a/pydra/tasks/freesurfer/mri_convert.py
+++ b/pydra/tasks/freesurfer/mri_convert.py
@@ -7,7 +7,7 @@ __all__ = ["MRIConvert"]
 
 @attrs.define(slots=False, kw_only=True)
 class MRIConvertSpec(pydra.specs.ShellSpec):
-    input_volume: str = attrs.field(
+    input_volume_file: str = attrs.field(
         metadata={
             "help_string": "input volume",
             "mandatory": True,
@@ -16,7 +16,7 @@ class MRIConvertSpec(pydra.specs.ShellSpec):
         }
     )
 
-    output_volume: str = attrs.field(
+    output_volume_file: str = attrs.field(
         metadata={
             "help_string": "output volume",
             "argstr": "",
@@ -44,8 +44,8 @@ class MRIConvert(pydra.ShellCommandTask):
     1. Convert data to float:
 
     >>> task = MRIConvert(
-    ...     input_volume="orig.nii.gz",
-    ...     output_volume="float.nii.gz",
+    ...     input_volume_file="orig.nii.gz",
+    ...     output_volume_file="float.nii.gz",
     ...     output_data_type="float",
     ... )
     >>> task.cmdline

--- a/pydra/tasks/freesurfer/mri_vol2vol.py
+++ b/pydra/tasks/freesurfer/mri_vol2vol.py
@@ -11,21 +11,21 @@ __all__ = ["MRIVol2Vol"]
 
 @attrs.define(slots=False, kw_only=True)
 class MRIVol2VolSpec(pydra.specs.ShellSpec):
-    moving_volume: str = attrs.field(
+    moving_volume_file: str = attrs.field(
         metadata={
             "help_string": "moving volume (target volume if transform is inverted)",
             "argstr": "--mov",
         }
     )
 
-    target_volume: str = attrs.field(
+    target_volume_file: str = attrs.field(
         metadata={
             "help_string": "target volume (moving volume if transform is inverted)",
             "argstr": "--targ",
         }
     )
 
-    output_volume: str = attrs.field(
+    output_volume_file: str = attrs.field(
         metadata={
             "help_string": "output volume",
             "argstr": "--o",
@@ -112,8 +112,8 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     1. Resample functional data into anatomical space:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="func.nii.gz",
-    ...     output_volume="func-in-anat.mgh",
+    ...     moving_volume_file="func.nii.gz",
+    ...     output_volume_file="func-in-anat.mgh",
     ...     registration_file="register.dat",
     ...     use_registered_volume_as_target=True,
     ... )
@@ -123,8 +123,8 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     2. Resample anatomical data into functional space:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="func.nii.gz",
-    ...     output_volume="anat-in-func.mgh",
+    ...     moving_volume_file="func.nii.gz",
+    ...     output_volume_file="anat-in-func.mgh",
     ...     registration_file="register.dat",
     ...     use_registered_volume_as_target=True,
     ...     invert_transform=True,
@@ -135,8 +135,8 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     3. Map functional to anatomical without resampling:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="func.nii.gz",
-    ...     output_volume="func.new.vox2ras.nii.gz",
+    ...     moving_volume_file="func.nii.gz",
+    ...     output_volume_file="func.new.vox2ras.nii.gz",
     ...     registration_file="register.dat",
     ...     use_registered_volume_as_target=True,
     ...     no_resampling=True,
@@ -147,8 +147,8 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     4. Map a binary mask in functional space to anatomical space:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="mask.nii.gz",
-    ...     output_volume="mask-in-anat.mgh",
+    ...     moving_volume_file="mask.nii.gz",
+    ...     output_volume_file="mask-in-anat.mgh",
     ...     registration_file="register.dat",
     ...     use_registered_volume_as_target=True,
     ...     interpolation="nearest",
@@ -159,8 +159,8 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     5. Map functional data to talairach (MNI305) space with 2mm isotropic resolution:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="func.nii.gz",
-    ...     output_volume="func-in-tal.2mm.mgh",
+    ...     moving_volume_file="func.nii.gz",
+    ...     output_volume_file="func-in-tal.2mm.mgh",
     ...     registration_file="register.dat",
     ...     resample_to_talairach=True,
     ...     talairach_resolution=2,
@@ -171,9 +171,9 @@ class MRIVol2Vol(pydra.ShellCommandTask):
     6. Apply an MNI transform by resampling the anatomical data into talairach space:
 
     >>> task = MRIVol2Vol(
-    ...     moving_volume="orig.mgz",
-    ...     target_volume="$FREESURFER_HOME/average/mni305.cor.mgz",
-    ...     output_volume="orig-in-mni305.mgz",
+    ...     moving_volume_file="orig.mgz",
+    ...     target_volume_file="$FREESURFER_HOME/average/mni305.cor.mgz",
+    ...     output_volume_file="orig-in-mni305.mgz",
     ...     xfm_registration_file="transforms/talairach.xfm",
     ... )
     >>> task.cmdline

--- a/pydra/tasks/freesurfer/mris_expand.py
+++ b/pydra/tasks/freesurfer/mris_expand.py
@@ -7,7 +7,7 @@ __all__ = ["MRISExpand"]
 
 @attrs.define(slots=False, kw_only=True)
 class MIRSExpandSpec(pydra.specs.ShellSpec):
-    input_surface: str = attrs.field(
+    input_surface_file: str = attrs.field(
         metadata={
             "help_string": "input surface",
             "mandatory": True,
@@ -36,12 +36,12 @@ class MIRSExpandSpec(pydra.specs.ShellSpec):
         }
     )
 
-    output_surface: str = attrs.field(
+    output_surface_file: str = attrs.field(
         metadata={
             "help_string": "output surface",
             "argstr": "",
             "position": -1,
-            "output_file_template": "{input_surface}_expanded",
+            "output_file_template": "{input_surface_file}_expanded",
         }
     )
 
@@ -76,7 +76,7 @@ class MRISExpand(pydra.ShellCommandTask):
     1. Expand by cortical thickness:
 
     >>> task = MRISExpand(
-    ...     input_surface="lh.white",
+    ...     input_surface_file="lh.white",
     ...     fraction_of_cortical_thickness=0.5,
     ... )
     >>> task.cmdline    # doctest: +ELLIPSIS
@@ -85,9 +85,9 @@ class MRISExpand(pydra.ShellCommandTask):
     2. Expand by distance from label:
 
     >>> task = MRISExpand(
-    ...     input_surface="lh.white",
+    ...     input_surface_file="lh.white",
     ...     distance=0.5,
-    ...     output_surface="lh.graymid",
+    ...     output_surface_file="lh.graymid",
     ...     label="labelfile",
     ... )
     >>> task.cmdline

--- a/pydra/tasks/freesurfer/mris_preproc.py
+++ b/pydra/tasks/freesurfer/mris_preproc.py
@@ -12,7 +12,7 @@ __all__ = ["MRISPreproc"]
 @attrs.define(slots=False, kw_only=True)
 class MRISPreprocSpec(pydra.specs.ShellSpec):
 
-    output_file: str = attrs.field(
+    output_surface_file: str = attrs.field(
         metadata={
             "help_string": "output file",
             "argstr": "--out",
@@ -119,7 +119,7 @@ class MRISPreproc(pydra.ShellCommandTask):
     ...     target_subject_id="fsaverage",
     ...     hemisphere="lh",
     ...     measure="thickness",
-    ...     output_file="abc-lh-thickness.mgh",
+    ...     output_surface_file="abc-lh-thickness.mgh",
     ... )
     >>> task.cmdline
     'mris_preproc --out abc-lh-thickness.mgh --target fsaverage --hemi lh --meas thickness \
@@ -132,7 +132,7 @@ class MRISPreproc(pydra.ShellCommandTask):
     ...     target_subject_id="fsaverage",
     ...     hemisphere="lh",
     ...     measure="thickness",
-    ...     output_file="abc-lh-thickness.mgh",
+    ...     output_surface_file="abc-lh-thickness.mgh",
     ... )
     >>> task.cmdline
     'mris_preproc --out abc-lh-thickness.mgh --target fsaverage --hemi lh --meas thickness --fsgd abc.fsgd'
@@ -144,7 +144,7 @@ class MRISPreproc(pydra.ShellCommandTask):
     ...     target_subject_id="fsaverage",
     ...     hemisphere="lh",
     ...     measure="thickness",
-    ...     output_file="abc-lh-thickness.sm5.mgh",
+    ...     output_surface_file="abc-lh-thickness.sm5.mgh",
     ...     target_smoothing=5,
     ... )
     >>> task.cmdline
@@ -156,7 +156,7 @@ class MRISPreproc(pydra.ShellCommandTask):
     >>> task = MRISPreproc(
     ...     target_subject_id="fsaverage",
     ...     hemisphere="lh",
-    ...     output_file="abc-lh-thickness.mgh",
+    ...     output_surface_file="abc-lh-thickness.mgh",
     ...     fsgd_file="abc.fsgd",
     ...     source_format="curv",
     ...     input_surface_measures=[f"abc{s:02d}-anat/surf/lh.thickness" for s in range(1, 5)],
@@ -173,7 +173,7 @@ class MRISPreproc(pydra.ShellCommandTask):
     ...     target_subject_id="fsaverage",
     ...     hemisphere="lh",
     ...     measure="thickness",
-    ...     output_file="abc-lh-thickness-pdiff.mgh",
+    ...     output_surface_file="abc-lh-thickness-pdiff.mgh",
     ...     compute_paired_differences=True,
     ... )
     >>> task.cmdline

--- a/pydra/tasks/freesurfer/recon_all/__init__.py
+++ b/pydra/tasks/freesurfer/recon_all/__init__.py
@@ -10,7 +10,7 @@ In addition, the longitudinal processing interfaces to `recon-all` are available
 1. Cross-sectionally process timepoints:
 >>> task = ReconAll(
 ...     subject_id="tp1",
-...     t1_volume="/path/to/tp1.dcm",
+...     t1_volume_file="/path/to/tp1.dcm",
 ... )
 >>> task.cmdline
 'recon-all -subjid tp1 -i /path/to/tp1.dcm -all'

--- a/pydra/tasks/freesurfer/recon_all/base_recon_all.py
+++ b/pydra/tasks/freesurfer/recon_all/base_recon_all.py
@@ -17,7 +17,7 @@ class BaseReconAllSpec(pydra.specs.ShellSpec):
         metadata={
             "help_string": "base template identifier",
             "mandatory": True,
-            "argstr": "-base {base_template_id}",
+            "argstr": "-base",
         }
     )
 

--- a/pydra/tasks/freesurfer/recon_all/long_recon_all.py
+++ b/pydra/tasks/freesurfer/recon_all/long_recon_all.py
@@ -24,8 +24,7 @@ class LongReconAllSpec(pydra.specs.ShellSpec):
         metadata={
             "help_string": "longitudinal template identifier",
             "argstr": None,
-            "requires": ["longitudinal_timepoint_id"],
-        },
+        }
     )
 
 

--- a/pydra/tasks/freesurfer/recon_all/recon_all.py
+++ b/pydra/tasks/freesurfer/recon_all/recon_all.py
@@ -18,37 +18,37 @@ class ReconAllSpec(pydra.specs.ShellSpec):
         metadata={
             "help_string": "subject identifier",
             "mandatory": True,
-            "argstr": "-subjid {subject_id}",
+            "argstr": "-subjid",
         }
     )
 
-    t1_volume: os.PathLike = attrs.field(
+    t1_volume_file: os.PathLike = attrs.field(
         metadata={
             "help_string": "input T1 volume",
-            "argstr": "-i {t1_volume}",
-            "xor": ["t1_volumes"],
+            "argstr": "-i",
+            "xor": ["t1_volume_files"],
         }
     )
 
-    t1_volumes: ty.Iterable[os.PathLike] = attrs.field(
+    t1_volume_files: ty.Iterable[os.PathLike] = attrs.field(
         metadata={
             "help_string": "input T1 volumes",
             "argstr": "-i...",
-            "xor": ["t1_volume"],
+            "xor": ["t1_volume_file"],
         }
     )
 
-    t2_volume: os.PathLike = attrs.field(
+    t2_volume_file: os.PathLike = attrs.field(
         metadata={
             "help_string": "input T2 volume",
-            "argstr": "-t2 {t2_volume}",
+            "argstr": "-t2",
         }
     )
 
-    flair_volume: os.PathLike = attrs.field(
+    flair_volume_file: os.PathLike = attrs.field(
         metadata={
             "help_string": "input FLAIR volume",
-            "argstr": "-flair {flair_volume}",
+            "argstr": "-flair",
         }
     )
 

--- a/pydra/tasks/freesurfer/recon_all/specs.py
+++ b/pydra/tasks/freesurfer/recon_all/specs.py
@@ -39,10 +39,10 @@ class ReconAllBaseSpec(pydra.specs.ShellSpec):
         },
     )
 
-    custom_brain_mask: os.PathLike = attrs.field(
+    custom_brain_mask_file: os.PathLike = attrs.field(
         metadata={
             "help_string": "use a custom brain mask",
-            "argstr": "-xmask {custom_brain_mask}",
+            "argstr": "-xmask",
         },
     )
 
@@ -82,7 +82,7 @@ class ReconAllBaseSpec(pydra.specs.ShellSpec):
         }
     )
 
-    custom_talairach_atlas: os.PathLike = attrs.field(
+    custom_talairach_atlas_file: os.PathLike = attrs.field(
         metadata={
             "help_string": "use a custom talairach atlas",
             "argstr": "-custom-tal-atlas",

--- a/pydra/tasks/freesurfer/tkregister2.py
+++ b/pydra/tasks/freesurfer/tkregister2.py
@@ -7,7 +7,7 @@ __all__ = ["TkRegister2"]
 
 @attrs.define(slots=False, kw_only=True)
 class TkRegister2Spec(pydra.specs.ShellSpec):
-    moving_volume: str = attrs.field(
+    moving_volume_file: str = attrs.field(
         metadata={
             "help_string": "moving volume",
             "mandatory": True,
@@ -15,7 +15,7 @@ class TkRegister2Spec(pydra.specs.ShellSpec):
         }
     )
 
-    target_volume: str = attrs.field(
+    target_volume_file: str = attrs.field(
         metadata={
             "help_string": "target volume",
             "mandatory": True,
@@ -51,8 +51,8 @@ class TkRegister2(pydra.ShellCommandTask):
     1. Create a registration matrix between the conformed space (orig.mgz) and the native anatomical (rawavg.mgz):
 
     >>> task = TkRegister2(
-    ...     moving_volume="rawavg.mgz",
-    ...     target_volume="orig.mgz",
+    ...     moving_volume_file="rawavg.mgz",
+    ...     target_volume_file="orig.mgz",
     ...     registration_file="register.native.dat",
     ...     compute_registration_from_headers=True,
     ... )


### PR DESCRIPTION
Use `_file` as suffix for all parameters accepting a path to a file, in addition to `_id` for FreeSurfer idenfitiers and `_dir` for directories.